### PR TITLE
Only interleave on load/store instructions

### DIFF
--- a/final_proj/code/equiv-threads.h
+++ b/final_proj/code/equiv-threads.h
@@ -27,6 +27,7 @@ typedef struct eq_th {
 
     // how many instructions we executed.
     uint32_t inst_cnt;
+    uint32_t loadstr_cnt;
     unsigned verbose_p;  // if you want alot of information.
 } eq_th_t;
 

--- a/final_proj/code/interleaver.c
+++ b/final_proj/code/interleaver.c
@@ -17,7 +17,7 @@ size_t init_threads(eq_th_t **thread_arr, function_exec* executables, int **itl,
         let th = equiv_fork(executables[itl[0][f_idx]].func_addr, NULL, 0);
         thread_arr[f_idx] = th;
         equiv_run();
-        num_instrs[f_idx] = th->inst_cnt;
+        num_instrs[f_idx] = th->loadstr_cnt;
     }
     size_t total_instrs = 0;
     for (int i = 0; i < num_funcs; i++) {

--- a/final_proj/code/interleaver.c
+++ b/final_proj/code/interleaver.c
@@ -182,7 +182,6 @@ void run_interleavings(function_exec* executables, size_t num_funcs, int **itl, 
             }
             printk("\n");
         }
-        //continue;
 
         // load next schedule
         set_ctx_switches(tids[sched_idx], instr_nums[sched_idx], actual_ncs); 

--- a/final_proj/code/sha256.c
+++ b/final_proj/code/sha256.c
@@ -111,23 +111,6 @@ void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len)
 	}
 }
 
-// void sha256_update_state(SHA256_CTX *ctx, variable_state* var_states){
-//     size_t num_vars = sizeof(var_states)/sizeof(var_states[0]);
-//     size_t total_bytes = 0;
-//     for(size_t i = 0; i < num_vars; i++){
-//         total_bytes += var_states[i].num_bytes;
-//     }
-//     void* data = malloc(total_bytes);
-//     void* curr_data_pointer = data;
-//     for(size_t i = 0; i < num_vars; i++){
-//         memcpy(curr_data_pointer, var_states[i].var_addr, var_states[i].num_bytes);
-//         curr_data_pointer += var_states[i].num_bytes;
-//     }
-
-//     sha256_update(ctx, (BYTE*)data, total_bytes);
-//     free(data);
-// }
-
 void sha256_final(SHA256_CTX *ctx, BYTE hash[])
 {
 	WORD i;

--- a/final_proj/code/state-space.c
+++ b/final_proj/code/state-space.c
@@ -10,6 +10,7 @@
 POTENTIAL TODOS:
 1) Memory - Read/write set consistency with VM
 2) Speed - run interleaving after generating each permutation
+3) General - compile at a higher optimization (also will reduce instructions which reduces speed)
 */
 
 /*


### PR DESCRIPTION
Use fault_pc to figure out what instruction we break on, and only respond to loads/stores. Should prevent a lot of unnecessary interleaving.